### PR TITLE
NPMify it please

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "rosetta.js",
+  "version": "1.0.0",
+  "description": "A possible, extensible collection of compilers to native ECMAScript.",
+  "main": "rosetta.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/adamcarheden/rosetta.js.git"
+  },
+  "author": "madmurpth",
+  "license": "GPL-3.0",
+  "bugs": {
+    "url": "https://github.com/adamcarheden/rosetta.js/issues"
+  },
+  "homepage": "https://github.com/adamcarheden/rosetta.js#readme"
+}

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "type": "git",
     "url": "git+https://github.com/madmurphy/rosetta.js.git"
   },
-  "author": "madmurpth",
+  "author": "madmurphy",
   "license": "GPL-3.0",
   "bugs": {
     "url": "https://github.com/madmurphy/rosetta.js/issues"

--- a/package.json
+++ b/package.json
@@ -15,5 +15,5 @@
   "bugs": {
     "url": "https://github.com/adamcarheden/rosetta.js/issues"
   },
-  "homepage": "https://github.com/adamcarheden/rosetta.js#readme"
+  "homepage": "https://developer.mozilla.org/en-US/Add-ons/Code_snippets/Rosetta"
 }

--- a/package.json
+++ b/package.json
@@ -8,12 +8,12 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/adamcarheden/rosetta.js.git"
+    "url": "git+https://github.com/madmurphy/rosetta.js.git"
   },
   "author": "madmurpth",
   "license": "GPL-3.0",
   "bugs": {
-    "url": "https://github.com/adamcarheden/rosetta.js/issues"
+    "url": "https://github.com/madmurphy/rosetta.js/issues"
   },
   "homepage": "https://developer.mozilla.org/en-US/Add-ons/Code_snippets/Rosetta"
 }


### PR DESCRIPTION
I wanted to depend on this project via npm, but there's no package.js. This pull adds one.

Possibly also consider publishing it via npm so we can use it by name instead of the github URL:
https://docs.npmjs.com/cli/publish
